### PR TITLE
Pointing out 4 unused variables indicated by Free Pascal compiler

### DIFF
--- a/src/Pascal/CARGA22.PAS
+++ b/src/Pascal/CARGA22.PAS
@@ -39,8 +39,15 @@ uses crt;
 {Definição das variáveis utilizadas}
 var xt,xk,g,h,MT,po2,NCcarr,feg,PCcarr,CRmax,CRmin,Pcoq,PCqu,PCI,                   
     TeorCM,CF,PCIesc,PCIrat,PCIratmx,FR,Vo2,Vsopro,Vazao,TeorMM,MTC,CRate:real;
+
+    {From compiler - Note: Local variable "z" not used}
     t,cont,y,z:integer;
+
+    {From compiler - Note: Local variable "s" not used}
+    {From compiler - Note: Local variable "c" not used}
+    {From compiler - Note: Local variable "i" not used}
     s,resp,c,i,opcao:char;
+
     Texto:text;
     PropM: array[1..3] of real;
     TeorM: array[1..3] of real;

--- a/src/Pascal/CARGA22.PAS
+++ b/src/Pascal/CARGA22.PAS
@@ -40,13 +40,9 @@ uses crt;
 var xt,xk,g,h,MT,po2,NCcarr,feg,PCcarr,CRmax,CRmin,Pcoq,PCqu,PCI,                   
     TeorCM,CF,PCIesc,PCIrat,PCIratmx,FR,Vo2,Vsopro,Vazao,TeorMM,MTC,CRate:real;
 
-    {From compiler - Note: Local variable "z" not used}
-    t,cont,y,z:integer;
+    t,cont,y:integer;
 
-    {From compiler - Note: Local variable "s" not used}
-    {From compiler - Note: Local variable "c" not used}
-    {From compiler - Note: Local variable "i" not used}
-    s,resp,c,i,opcao:char;
+    resp,opcao:char;
 
     Texto:text;
     PropM: array[1..3] of real;


### PR DESCRIPTION
@GustavoCoqui : Indiquei as 4 variáveis marcadas pelo compilador como sem uso. Não removi ainda. Mas já deixei marcado para avaliação.

![image](https://user-images.githubusercontent.com/36424026/186296015-a6a0c75c-c69e-4d8c-ab07-10b0278b5d11.png)
