### PR TITLE
Disouzam/issue/9 fix typos encoding in original pascal implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,9 @@ src/Pascal/backup
 # dotnet files
 **/obj
 **/bin
+**/.vs
+
+# Pascal files
+src/Pascal/lib/x86_64-win64
+*.lps
+*.exe

--- a/src/Pascal/CALCULO.DOC
+++ b/src/Pascal/CALCULO.DOC
@@ -1,52 +1,53 @@
                                 DADOS DE ENTRADA
 
-------------------------------------GUSA:---------------------------------------                             Gusa:   1.00 ton (95.50 % de Fe, 4.50 % de C.).
+------------------------------------GUSA:---------------------------------------
+                             Gusa:   1.00 ton (95.00 % de Fe, 4.00 % de C.).
 
-----------------------------------MINERIOS:-------------------------------------
+----------------------------------MINÉRIOS:-------------------------------------
 
-               Minerio           Proporcao(%)           Teor(%)
-               Minerio 1          100.00                 70.00
-                                    TEOR MEDIO DE FERRO: 70.00%.
+               Minério           Proporção(%)           Teor(%)
+               Minério 1          100.00                 65.00
+                                    TEOR MÉDIO DE FERRO: 65.00%.
 
 -----------------------------------COQUE:---------------------------------------
 
-               Coque             Proporcao(%)           Teor(%)
-               Coque 1            100.00                 100.00
-                                  TEOR MEDIO DE CARBONO: 100.00%.
+               Coque             Proporção(%)           Teor(%)
+               Coque 1            100.00                  90.00
+                                  TEOR MÉDIO DE CARBONO: 90.00%.
 
-                           TEOR DE CARBONO NO PCI: 100.00%.
-                        TEOR DE OXIGENIO NO SOPRO: 21.00%.
-                      Quantidade de PCI adicionada:    0.00 ton.
+                           TEOR DE CARBONO NO PCI: 80.00%.
+                        TEOR DE OXIGÊNIO NO SOPRO: 21.00%.
+                      Quantidade de PCI adicionada:    0.10 ton.
 
 
 
 
                                RESULTADOS
 
---------------------------------MINERIOS----------------------------------------
-                        Massa de minerio 1:    1.36 ton.
-                        TOTAL CARREGADO:    1.36 toneladas por dia.
+--------------------------------MINÉRIOS----------------------------------------
+                        Massa de minério 1:    1.46 ton.
+                        TOTAL CARREGADO:    1.46 toneladas por dia.
 
 ---------------------------------COQUE------------------------------------------
-                        Massa do coque 1:    0.48 ton.
-                        TOTAL CARREGADO:    0.48 toneladas por dia.
+                        Massa do coque 1:    0.44 ton.
+                        TOTAL CARREGADO:    0.44 toneladas por dia.
 
 ----------------------------------PCI-------------------------------------------
-                        Massa do PCI:  0.00 ton
+                        Massa do PCI:  0.10 ton
 
 ---------------------------------RATES------------------------------------------
-                        Coke Rate:  478.84 kg/ton de gusa
-                        Coke Rate maximo:  478.84 kg/ton de gusa
-                        Coke Rate minimo:  249.64 kg/ton de gusa
+                        Coke Rate:  435.08 kg/ton de gusa
+                        Coke Rate máximo:  523.97 kg/ton de gusa
+                        Coke Rate mínimo:  270.63 kg/ton de gusa
 
-                        PCI Rate:    0.00 kg/ton de gusa
-                        PCI Rate maximo: 229.20 Kg/ton de gusa
+                        PCI Rate:  100.00 kg/ton de gusa
+                        PCI Rate máximo: 285.00 Kg/ton de gusa
 
-                        Fuel Rate:  478.84 kg/ton de gusa
+                        Fuel Rate:  535.08 kg/ton de gusa
 
 -----------------------------DADOS DE SOPRO-------------------------------------
-                        Volume de oxigenio consumido: 213.92Nm3/dia.
-                        Volume de sopro:  0.71Nm3/min
+                        Volume de oxigênio consumido: 212.80Nm3/dia.
+                        Volume de sopro:  0.70Nm3/min
 
 
 

--- a/src/Pascal/CARGA22.PAS
+++ b/src/Pascal/CARGA22.PAS
@@ -33,6 +33,13 @@ Após o uso do programa, pode-se armazenar os dados em um arquivo texto
 
 }
 
+{
+  enconding: Windows-1252 - https://www.ascii-code.com/
+
+  "ASCII, stands for American Standard Code for Information Interchange. It's a 7-bit character code where every single bit represents a unique character. On this webpage you will find 8 bits, 256 characters, ASCII table according to Windows-1252 (code page 1252) which is a superset of ISO 8859-1 in terms of printable characters. In the range 128 to 159 (hex 80 to 9F), ISO/IEC 8859-1 has invisible control characters, while Windows-1252 has writable characters. Windows-1252 is probably the most-used 8-bit character encoding in the world."
+
+}
+
 {Definição da biblioteca a ser utilizada}
 uses crt;
 

--- a/src/Pascal/CARGA22.PAS
+++ b/src/Pascal/CARGA22.PAS
@@ -65,16 +65,6 @@ begin
   gotoxy(1,24);
   write('Pressione qualquer tecla para continuar.');
   readkey;
-  cont:=1;
-
-  {Loop para funções gráficas de apresentação do programa}
-  while cont <=40 do 
-  begin
-    write(#220);
-    cont:=cont+1;
-    delay(40);
-  end;
-
   Textmode(3);
   TextColor(15);
   resp:= 's';

--- a/src/Pascal/CARGA22.PAS
+++ b/src/Pascal/CARGA22.PAS
@@ -181,7 +181,7 @@ begin
     textcolor(12);
 
     {Início da entrada de dados}
-    writeln('                   QUANTIDADE E COMPOSIÇAO DO GUSA');
+    writeln('                   QUANTIDADE E COMPOSI',#199,#195,'O DO GUSA');
     textcolor(15);
     writeln;
     writeln;
@@ -193,7 +193,7 @@ begin
 
     {Loop de detecção de erros na execução}
     repeat 
-      writeln('Informe o teor de ferro e carbono no gusa que ser',#160,' produzido.');
+      writeln('Informe o teor de ferro e carbono no gusa que ser',#225,' produzido.');
       write('Teor de ferro:');
 
       {Leitura do teor de ferro no gusa} 
@@ -215,14 +215,14 @@ begin
 
     clrscr;
     textcolor(12);
-    writeln('                           TIPOS DE MINERIO');
+    writeln('                           TIPOS DE MIN',#201,'RIO');
     textcolor(15);
     writeln;
     writeln;
     repeat
 
       {Leitura do número de minérios (ou similares) a serem utilizados}
-      Writeln('Quantos tipos de minérios serao utilizados(m',#160,'ximo de 3)?');
+      writeln('Quantos tipos de min',#233,'rios ser'#227'o utilizados (m',#225,'ximo de 3)?');
       readln(t);
 
       writeln;
@@ -241,7 +241,7 @@ begin
     writeln;
     textcolor(12);
     writeln;
-    writeln('                 PROPORÇÃO DE MINERIO E TEOR DE FERRO');
+    writeln('                 PROPOR',#199,#195,'O DE MIN',#201,'RIO E TEOR DE FERRO');
     textcolor(15);
     writeln;
     writeln;
@@ -252,7 +252,7 @@ begin
       begin
 
         {Leitura do teor de ferro, no caso de um só minério}
-        writeln('Informe o teor de ferro no minerio.');
+        writeln('Informe o teor de ferro no min',#233,'rio.');
         readln(TeorM[1]);
 
         PropM[1]:=100;
@@ -264,10 +264,10 @@ begin
         {Leitura da proporção e do teor de ferro para cada minério, para o caso de mais de um minério}
         while cont<=t do 
         begin
-          writeln('Informe a proporcao do minerio ',cont,' e o teor de ferro nele.');
+          writeln('Informe a propor',#231,#227,'o do min',#233,'rio ',cont,' e o teor de ferro nele.');
 
           {Leitura da proporção para cada minério}
-          write('Proporcao:');
+          write('Propor',#231,#227,'o:');
           readln(PropM[cont]);
 
           {Leitura do teor de ferro para cada minério}
@@ -300,7 +300,7 @@ begin
 
     repeat
       {Leitura do número de coques a serem utilizados}
-      writeln('Quantos tipos de coque serao utilizados(m',#160,'ximo de 3)?');
+      writeln('Quantos tipos de coque ser',#227,'o utilizados (m',#225,'ximo de 3)?');
       readln(y);
       writeln;
 
@@ -318,7 +318,7 @@ begin
     writeln;
     writeln;
     textcolor(12);
-    writeln('                          PROPORÇÃO E TEOR DE CARBONO');
+    writeln('                          PROPOR',#199,#195,'O E TEOR DE CARBONO');
     textcolor(15);
     writeln;
     repeat
@@ -337,10 +337,10 @@ begin
         {Leitura da proporção e do teor de carbono para cada coque, para o caso de mais de um coque}
         while cont <=y do 
         begin
-          writeln('Informe a propor',#135,'ao do coque ',cont,' na mistura e teor de carbono fixo nele.');
+          writeln('Informe a propor',#231,#227,'o do coque ',cont,' na mistura e teor de carbono fixo nele.');
 
           {Leitura da proporção para cada coque}
-          write('Propor',#135,'ao:');
+          write('Propor',#231,#227,'o:');
           readln(PropC[cont]);
 
           {Leitura do teor de carbono para cada coque}
@@ -426,7 +426,7 @@ begin
     PCI:=PCI/1000;
     writeln;
     repeat
-      writeln('Você poderá usar no máximo ',PCI:10:3,' toneladas de PCI.');
+      writeln('Voc',#234,' poder',#225,' usar no m',#225,'ximo ',PCI:10:3,' toneladas de PCI.');
 
       {Leitura da massa de PCI adicionada}
       write('Informe um valor em toneladas:');
@@ -477,14 +477,14 @@ begin
 
     clrscr;
     textcolor(12);
-    writeln('                            TEOR DE OXIGENIO NO SOPRO');
+    writeln('                            TEOR DE OXIG',#202,'NIO NO SOPRO');
     textcolor(15);
     writeln;
     writeln;
-    writeln('Informe o teor de oxigenio no sopro.');
+    writeln('Informe o teor de oxig',#234,'nio no sopro.');
 
     {Leitura do teor de oxigênio no sopro}
-    write('Teor de oxigenio:');
+    write('Teor de oxig',#234,'nio:');
     readln(po2);
 
     {Cálculo do volume}
@@ -543,27 +543,27 @@ begin
     textcolor(12);
     writeln;
 
-    writeln('----------------------------------MINERIOS:------------------------------------');
+    writeln('----------------------------------MIN',#201,'RIOS:------------------------------------');
     textcolor(15);
-    writeln('Minerio           Proporcao(%)           Teor(%)');
+    writeln('Min',#233,'rio           Propor',#231,#227,'o(%)           Teor(%)');
     cont:=1;
 
     while cont <=t do
     begin
       {Apresentação da proporção de
       cada minério na carga e do respectivo teor de ferro}
-      writeln('Minerio ',cont,'         ',PropM[cont]:7:2,'              ',TeorM[cont]:7:2);
+      writeln('Min',#233,'rio ',cont,'         ',PropM[cont]:7:2,'              ',TeorM[cont]:7:2);
       cont:=cont+1;
     end;
 
     {Apresentação do teor médio de ferro na carga}
-    writeln('                     TEOR MEDIO DE FERRO: ',TeorMM:3:2,'%.');
+    writeln('                     TEOR M',#201,'DIO DE FERRO: ',TeorMM:3:2,'%.');
     textcolor(12);
 
     writeln;
     writeln('-----------------------------------COQUE:--------------------------------------');
     textcolor(15);
-    writeln('Coque             Proporcao(%)           Teor(%)');
+    writeln('Coque             Propor',#231,#227,'o(%)           Teor(%)');
 
     cont:=1;
 
@@ -578,7 +578,7 @@ begin
 
     {Apresentação do
     teor médio de carbono fixo na carga}
-    writeln('                   TEOR MEDIO DE CARBONO: ',TeorCM:3:2,'%.');
+    writeln('                   TEOR M',#201,'DIO DE CARBONO: ',TeorCM:3:2,'%.');
 
     writeln;
 
@@ -586,7 +586,7 @@ begin
     writeln('TEOR DE CARBONO NO PCI: ',CF:3:2,'%.');
 
     {Apresentação do teor de oxigênio no sopro}
-    writeln('TEOR DE OXIGENIO NO SOPRO: ',po2:3:2,'%.');
+    writeln('TEOR DE OXIG',#202,'NIO NO SOPRO: ',po2:3:2,'%.');
 
     {Apresentação da quantidade de PCI adicionada}
     writeln('QUANTIDADE DE PCI ADICIONADA: ',PCIesc:7:2,' ton.');
@@ -636,7 +636,7 @@ begin
     while cont<= t do
     begin
       {Apresentação da massa de cada minério carregado}
-      writeln('Massa de minerio ',cont,': ',MasM[cont]:7:2,' ton.');
+      writeln('Massa de min',#233,'rio ',cont,': ',MasM[cont]:7:2,' ton.');
       cont:=cont+1;
     end;
 
@@ -678,11 +678,11 @@ begin
     textcolor(15);
 
     {Apresentação do Coke rate máximo (em uma operação ALL COKE)}
-    writeln('Coke Rate maximo: ',CRmax:7:2,' kg/ton de gusa');
+    writeln('Coke Rate m',#225,'ximo: ',CRmax:7:2,' kg/ton de gusa');
 
     {Apresentação do Coke rate teórico mínimo 
     (através da utilização da quantidade máxima de PCI)}
-    writeln('Coke Rate minimo: ',CRmin:7:2,' kg/ton de gusa');
+    writeln('Coke Rate m',#237,'nimo: ',CRmin:7:2,' kg/ton de gusa');
 
     writeln;
     textcolor(12);
@@ -696,7 +696,7 @@ begin
     textcolor(15);
 
     {Apresentação do PCI rate máximo permitido}
-    writeln('PCI Rate maximo: ',PCIratmx:5:2,' Kg/ton de gusa');
+    writeln('PCI Rate m',#225,'ximo: ',PCIratmx:5:2,' Kg/ton de gusa');
 
     textcolor(12);
     writeln;
@@ -708,7 +708,7 @@ begin
     textcolor(15);
 
     {Apresentação do volume de oxigênio consumido}
-    writeln('Volume de oxigenio consumido: ',Vo2:5:2,'Nm3/dia.');
+    writeln('Volume de oxig',#234,'nio consumido: ',Vo2:5:2,'Nm3/dia.');
 
     textcolor(12);
 
@@ -720,17 +720,17 @@ begin
 
     {Finalização da
     apresentação dos dados de entrada e dos resultados}
-    write('Pressione [Enter] para ir a tela de gravacao de resultados.');
+    write('Pressione [Enter] para ir a tela de grava',#231,#227,'o de resultados.');
 
     readln;
     clrscr;
 
     {Procedimentos para armazenamento dos dados em um arquivo texto}
-    Writeln('                               GRAVACAO DOS RESULTADOS');
+    Writeln('                               GRAVA',#199,#195,'O DOS RESULTADOS');
     writeln;
     writeln;
     writeln('Deseja criar um arquivo texto com os dados obtidos?');
-    write('Opcoes:(s)sim (n)nao?');
+    write('Op',#231,#245,'es:(s)sim (n)n',#227,'o?');
     readln(resp);
     writeln;
     writeln;
@@ -739,16 +739,16 @@ begin
     begin
       assign(Texto,'Calculo.doc');
       opcao:='i';
-      writeln('Sera criado um arquivo chamado: Calculo.doc.');
+      writeln('Ser',#225,' criado um arquivo chamado: Calculo.doc.');
       writeln;
       textcolor(12);
-      writeln('ATENCAO! Se esse arquivo já havia sido criado anteriormente e voce escolher a');
-      Writeln('opcao (c)criar,na proxima pergunta, ele será sobrescrito e TODOS os dados serao');
+      writeln('ATENCAO! Se esse arquivo j',#225,' havia sido criado anteriormente e voce escolher a');
+      Writeln('op',#231,#227,'o (c)criar,na pr',#243,'xima pergunta, ele ser',#225,' sobrescrito e TODOS os dados ser',#227,'o');
       writeln('perdidos.');
       writeln;
       textcolor(15);
       writeln('Deseja criar um arquivo ou continuar inserindo dados no arquivo atual?');
-      writeln('Opçoes:(c)criar (i)inserir):');
+      writeln('Op',#231,#245,'es:(c)criar (i)inserir):');
       readln(opcao);
 
       if opcao = 'c' then
@@ -763,25 +763,25 @@ begin
       {Formatação da apresentação dos dados de entrada e dos resultados no arquivo texto}
       writeln(Texto,'                                DADOS DE ENTRADA');
       writeln(Texto);
-      write(Texto,'------------------------------------GUSA:---------------------------------------');
+      writeln(Texto,'------------------------------------GUSA:---------------------------------------');
       writeln(Texto,'                             Gusa:',xt:7:2,' ton (',g:5:2,' % de Fe,',h:5:2,' % de C.).');
       writeln(Texto);
-      writeln(Texto,'----------------------------------MINERIOS:-------------------------------------');
+      writeln(Texto,'----------------------------------MIN',#201,'RIOS:-------------------------------------');
       writeln(Texto);
-      writeln(Texto,'               Minerio           Proporcao(%)           Teor(%)');
+      writeln(Texto,'               Min',#233,'rio           Propor',#231,#227,'o(%)           Teor(%)');
       cont:=1;
 
       while cont <=t do
       begin
-        writeln(Texto,'               Minerio ',cont,'         ',PropM[cont]:7:2,'               ',TeorM[cont]:7:2);
+        writeln(Texto,'               Min',#233,'rio ',cont,'         ',PropM[cont]:7:2,'               ',TeorM[cont]:7:2);
         cont:=cont+1;
       end;
 
-      writeln(Texto,'                                    TEOR MEDIO DE FERRO: ',TeorMM:3:2,'%.');
+      writeln(Texto,'                                    TEOR M',#201,'DIO DE FERRO: ',TeorMM:3:2,'%.');
       writeln(Texto);
       writeln(Texto,'-----------------------------------COQUE:---------------------------------------');
       writeln(Texto);
-      writeln(Texto,'               Coque             Proporcao(%)           Teor(%)');
+      writeln(Texto,'               Coque             Propor',#231,#227,'o(%)           Teor(%)');
 
       cont:=1;
       while cont <=y do
@@ -790,10 +790,10 @@ begin
         cont:=cont+1;
       end;
 
-      writeln(Texto,'                                  TEOR MEDIO DE CARBONO: ',TeorCM:3:2,'%.');
+      writeln(Texto,'                                  TEOR M',#201,'DIO DE CARBONO: ',TeorCM:3:2,'%.');
       writeln(Texto);
       writeln(Texto,'                           TEOR DE CARBONO NO PCI: ',CF:3:2,'%.');
-      writeln(Texto,'                        TEOR DE OXIGENIO NO SOPRO: ',po2:3:2,'%.');
+      writeln(Texto,'                        TEOR DE OXIG',#202,'NIO NO SOPRO: ',po2:3:2,'%.');
       writeln(Texto,'                      Quantidade de PCI adicionada: ',PCIesc:7:2,' ton.');
       readkey;
       writeln(Texto);
@@ -802,12 +802,12 @@ begin
       writeln(Texto);
       writeln(Texto,'                               RESULTADOS');
       writeln(Texto);
-      writeln(Texto,'--------------------------------MINERIOS----------------------------------------');
+      writeln(Texto,'--------------------------------MIN',#201,'RIOS----------------------------------------');
 
       cont:=1;
       while cont<= t do
       begin
-        writeln(Texto,'                        Massa de minerio ',cont,': ',MasM[cont]:7:2,' ton.');
+        writeln(Texto,'                        Massa de min',#233,'rio ',cont,': ',MasM[cont]:7:2,' ton.');
         cont:=cont+1;
       end;
 
@@ -831,17 +831,17 @@ begin
       writeln(Texto);
       writeln(Texto,'---------------------------------RATES------------------------------------------');
       writeln(Texto,'                        Coke Rate: ', CRate:7:2,' kg/ton de gusa');
-      writeln(Texto,'                        Coke Rate maximo: ',CRmax:7:2,' kg/ton de gusa');
-      writeln(Texto,'                        Coke Rate minimo: ',CRmin:7:2,' kg/ton de gusa');
+      writeln(Texto,'                        Coke Rate m',#225,'ximo: ',CRmax:7:2,' kg/ton de gusa');
+      writeln(Texto,'                        Coke Rate m',#237,'nimo: ',CRmin:7:2,' kg/ton de gusa');
       writeln(Texto);
 
       writeln(Texto,'                        PCI Rate: ',PCIrat :7:2,' kg/ton de gusa');
-      writeln(Texto,'                        PCI Rate maximo: ',PCIratmx:5:2,' Kg/ton de gusa');
+      writeln(Texto,'                        PCI Rate m',#225,'ximo: ',PCIratmx:5:2,' Kg/ton de gusa');
       writeln(Texto);
       writeln(Texto,'                        Fuel Rate: ',FR:7:2,' kg/ton de gusa');
       writeln(Texto);
       writeln(Texto,'-----------------------------DADOS DE SOPRO-------------------------------------');
-      writeln(Texto,'                        Volume de oxigenio consumido: ',Vo2:5:2,'Nm3/dia.');
+          writeln(Texto,'                        Volume de oxig',#234,'nio consumido: ',Vo2:5:2,'Nm3/dia.');
       writeln(Texto,'                        Volume de sopro: ',Vazao:5:2,'Nm3/min');
       writeln(Texto);
       writeln(Texto);
@@ -875,13 +875,13 @@ begin
   end;{end do while inicial}
 
   clrscr;
-  writeln('    Este programa foi elaborado por alunos do quarto período, do curso ');
+  writeln('    Este programa foi elaborado por alunos do quarto per',#237,'odo, do curso ');
   writeln('    de Tecnologia em Metalurgia e Materiais - CEFET/ES, Abril de 2006.');
   gotoxy(1,5);
   textcolor(11);
   writeln('                               ALUNOS:');
   writeln;
-  writeln('                   Daniel Figueiredo Leao Oliveira');
+  writeln('                   Daniel Figueiredo Le',#227,'o Oliveira');
   writeln;
   writeln('                        Dickson Alves de Souza');
   writeln;

--- a/src/Pascal/CARGA22.PAS
+++ b/src/Pascal/CARGA22.PAS
@@ -37,7 +37,7 @@ Após o uso do programa, pode-se armazenar os dados em um arquivo texto
 uses crt;
 
 {Definição das variáveis utilizadas}
-var xt,xk,g,h,MT,po2,NCcarr,feg,PCcarr,CRmax,CRmin,Pcoq,PCqu,PCI,                   
+var xt,xk,g,h,MT,po2,NCcarr,feg,PCcarr,CRmax,CRmin,Pcoq,PCqu,PCI,
     TeorCM,CF,PCIesc,PCIrat,PCIratmx,FR,Vo2,Vsopro,Vazao,TeorMM,MTC,CRate:real;
 
     t,cont,y:integer;
@@ -47,7 +47,7 @@ var xt,xk,g,h,MT,po2,NCcarr,feg,PCcarr,CRmax,CRmin,Pcoq,PCqu,PCI,
     Texto:text;
     PropM: array[1..3] of real;
     TeorM: array[1..3] of real;
-    PropC: array[1..3] of real;                       
+    PropC: array[1..3] of real;
     TeorC: array[1..3] of real;
     MasM: array[1..3] of real;
     MasC: array[1..3] of real;
@@ -56,7 +56,7 @@ begin
   clrscr;
 
   {Modo de apresentação}
-  textmode( 1 ); 
+  textmode( 1 );
 
   {Cor do texto}
   TextColor( 15 );
@@ -84,79 +84,79 @@ begin
    begin
 
     {Inicialização das variáveis, evitando-se erros nas equações}
-    
+
     {Massa de gusa (em toneladas)} 
-    xt:=0; 
-    
+    xt:=0;
+
     {Massa de gusa (em kilogramas)} 
     xk:=0;
-    
+
     {Teor de ferro no gusa(%)}
     g:=0;
-    
+
     {Teor de carbono no gusa(%)}
     h:=0;
-    
+
     {Massa total de minérios carregados} 
     MT:=0;
-    
+
     {Percentual de oxigênio no ar soprado}
     po2:=0;
-    
+
     {Número de kmols de carbono necessário para ser carregado}
     NCcarr:=0;
-    
+
     {Massa de carbono a ser carregado}
     PCcarr:=0;
-    
+
     {Coke rate máximo(em kg/ton de gusa)}
     CRmax:=0;
-    
+
     {Coke rate mínimo(em kg/ton de gusa)}
     CRmin:=0;
-    
+
     {Massa de coque (sem o uso de PCI)-para o cálculo do Coke rate máximo}
     Pcoq:=0;
-    
+
     {Massa de carbono queimado}
     PCqu:=0;
-    
+
     {Massa máxima de PCI que pode ser adicionada}
     PCI:=0;
-    
+
     {Teor médio de carbono fixo na carga de coques}
     TeorCM:=0;
-    
+
     {Teor de carbono no PCI}
     CF:=0;
-    
+
     {Massa de PCI, inferior à máxima massa permitida}
     PCIesc:=0;
-    
+
     {PCI rate (em kg/ton de gusa)}
     PCIrat:=0;
-    
+
     {PCI rate máximo (em kg/ton de gusa}
     PCIratmx:=0;
-    
+
     {Fuel rate (em kg/ton de gusa)} 
     FR:=0;
-    
+
     {Volume de oxigênio consumido(em Nm3/dia)}
     Vo2:=0;
-    
+
     {Volume de sopro (em Nm3/dia)}
     Vsopro:=0;
-    
+
     {Vazão do sopro(em Nm3/min)}
     Vazao:=0;
-    
+
     {Teor médio de ferro na carga dos minérios}
     TeorMM:=0;
-    
+
     {Massa total de coque carregado}
     MTC:=0;
-    
+
     {Coque rate (em kg/ton de gusa)}
     CRate:=0;
 
@@ -167,36 +167,36 @@ begin
     begin
       {Proporção do minério (1,2 ou 3) na carga de minérios}
       PropM[cont]:=0;
-      
+
       {Teor de ferro no minério (1,2 ou 3)}
       TeorM[cont]:=0;
-      
+
       {Massa do minério (1,2 ou 3) carregado}
       MasM[cont]:=0;
-      
+
       {Proporção do coque (1,2 ou 3)} 
       PropC[cont]:=0;
-      
+
       {Teor de carbono fixo no coque (1,2 ou 3)}
       TeorC[cont]:=0;
-      
+
       {Massa do coque (1,2 ou 3) carregado} 
       MasC[cont]:=0;
-      
+
       cont:=cont+1;
     end;
 
     clrscr;
     writeln;
     textcolor(12);
-    
+
     {Início da entrada de dados}
-    writeln('                   QUANTIDADE E COMPOSIÇAO DO GUSA'); 
+    writeln('                   QUANTIDADE E COMPOSIÇAO DO GUSA');
     textcolor(15);
     writeln;
     writeln;
     Write('Informe a quantidade de gusa que deve ser produzido (em toneladas):');
-    
+
     { Leitura da massa de gusa em toneladas}
     readln(xt);
     writeln;
@@ -207,8 +207,8 @@ begin
       write('Teor de ferro:');
 
       {Leitura do teor de ferro no gusa} 
-      readln(g); 
-      
+      readln(g);
+
       write('Teor de carbono:');
       readln(h);
       writeln;
@@ -217,12 +217,12 @@ begin
         textcolor(11);
 
         {Aviso de erro na digitação dos teores de ferro e carbono}
-        writeln('Dados incorretos!'); 
+        writeln('Dados incorretos!');
 
         textcolor(15);
       end;
     until g+h<=100;
-    
+
     clrscr;
     textcolor(12);
     writeln('                           TIPOS DE MINERIO');
@@ -233,7 +233,7 @@ begin
 
       {Leitura do número de minérios (ou similares) a serem utilizados}
       Writeln('Quantos tipos de minérios serao utilizados(m',#160,'ximo de 3)?');
-      readln(t); 
+      readln(t);
 
       writeln;
 
@@ -260,7 +260,7 @@ begin
     repeat   
       if t=1 then
       begin
-        
+
         {Leitura do teor de ferro, no caso de um só minério}
         writeln('Informe o teor de ferro no minerio.');
         readln(TeorM[1]);
@@ -275,14 +275,14 @@ begin
         while cont<=t do 
         begin
           writeln('Informe a proporcao do minerio ',cont,' e o teor de ferro nele.');
-          
+
           {Leitura da proporção para cada minério}
           write('Proporcao:');
-          readln(PropM[cont]); 
-          
+          readln(PropM[cont]);
+
           {Leitura do teor de ferro para cada minério}
           write('Teor de ferro:');
-          readln(TeorM[cont]); 
+          readln(TeorM[cont]);
 
           cont:=cont+1;
           writeln;
@@ -292,9 +292,9 @@ begin
       if PropM[1]+PropM[2]+PropM[3] <> 100 then 
       begin
         textcolor(11);
-        
+
         {Aviso de erro na digitação das proporções}
-        writeln('Dados incorretos!'); 
+        writeln('Dados incorretos!');
 
         textcolor(15);
       end;
@@ -311,15 +311,15 @@ begin
     repeat
       {Leitura do número de coques a serem utilizados}
       writeln('Quantos tipos de coque serao utilizados(m',#160,'ximo de 3)?');
-      readln(y); 
+      readln(y);
       writeln;
 
       if y > 3 then
       begin
         textcolor(11);
-        
+
         {Aviso de erro na digitação do número de coques}
-        writeln('Dado incorreto!'); 
+        writeln('Dado incorreto!');
 
         textcolor(15);
       end;
@@ -336,7 +336,7 @@ begin
       begin
         {Leitura do teor de  carbono fixo, no caso de um só coque}
         writeln('Informe o teor de carbono no coque.');
-        readln(TeorC[1]); 
+        readln(TeorC[1]);
 
         PropC[1]:=100;
       end
@@ -348,15 +348,15 @@ begin
         while cont <=y do 
         begin
           writeln('Informe a propor',#135,'ao do coque ',cont,' na mistura e teor de carbono fixo nele.');
-          
+
           {Leitura da proporção para cada coque}
           write('Propor',#135,'ao:');
-          readln(PropC[cont]); 
-          
+          readln(PropC[cont]);
+
           {Leitura do teor de carbono para cada coque}
           write('Teor de carbono:');
-          readln(TeorC[cont]); 
-          
+          readln(TeorC[cont]);
+
           cont:=cont+1;
           writeln;
         end;
@@ -364,16 +364,16 @@ begin
       if PropC[1]+PropC[2]+PropC[3] <> 100 then
       begin
         textcolor(11);
-        
+
         {Aviso de erro na digitação das proporções}
-        writeln('Dados incorretos!');  
+        writeln('Dados incorretos!');
 
         textcolor(15);
       end;
     until PropC[1]+PropC[2]+PropC[3]=100;
 
     clrscr;
-    
+
     {Conversão de unidades para a massa de gusa: de toneladas para kilogramas}
     xk:= xt*1000;
 
@@ -381,39 +381,39 @@ begin
     feg:= (xk*g)/(100);
 
     {Cálculo da massa total de minérios carregados (em kilogramas)}
-    MT:= (feg*10000)/(TeorM[1]*PropM[1]+TeorM[2]*PropM[2]+TeorM[3]*PropM[3]); 
+    MT:= (feg*10000)/(TeorM[1]*PropM[1]+TeorM[2]*PropM[2]+TeorM[3]*PropM[3]);
     cont:=1;
 
     while cont<= 3 do
     begin
       {Cálculo da massa individual de cada minério ( em kilogramas)}
-      MasM[cont]:= (PropM[cont]*MT/100); 
+      MasM[cont]:= (PropM[cont]*MT/100);
 
       {Conversão da massa individual de cada minério de kilogramas para toneladas} 
-      MasM[cont]:=MasM[cont]/1000; 
+      MasM[cont]:=MasM[cont]/1000;
       cont:= cont+1;
     end;
     cont:=1;
 
     {Cálculo do número de kmols de carbono a serem carregados}
-    NCcarr:=(2.12*feg)/(56)+(xk*h)/(1200); 
+    NCcarr:=(2.12*feg)/(56)+(xk*h)/(1200);
 
     {Cálculo da massa de carbono a ser carregada (em kilogramas)}
-    PCcarr:=NCcarr*12; 
+    PCcarr:=NCcarr*12;
 
     {Cálculo do teor médio de carbono fixo na mistura de coques}
-    TeorCM:=(TeorC[1]*PropC[1]+TeorC[2]*PropC[2]+TeorC[3]*PropC[3])/100; 
+    TeorCM:=(TeorC[1]*PropC[1]+TeorC[2]*PropC[2]+TeorC[3]*PropC[3])/100;
 
     {peso de coque sem uso de PCI }
     Pcoq:= PCcarr/(TeorCM/100);
 
     cont:=1;
-    
+
     {Cálculo do coke rate máximo (em kilogramas/ ton de gusa)}
-    CRmax:=Pcoq/xt; 
-    
+    CRmax:=Pcoq/xt;
+
     {Cálculo da massa de carbono queimado (em kilogramas)}
-    PCqu:=(0.02*feg)*(12); 
+    PCqu:=(0.02*feg)*(12);
 
     writeln;
     textcolor(12);
@@ -424,32 +424,32 @@ begin
 
     {Leitura do teor de carbono fixo no PCI}
     writeln('Informe o teor de carbono no PCI:');
-    readln(CF); 
-    
+    readln(CF);
+
     {Cálculo da massa máxima de PCI permitida (em kilogramas)}
-    PCI:=(PCqu)/(CF/100); 
-    
+    PCI:=(PCqu)/(CF/100);
+
     {Cálculo do PCI rate máximo (em kilogramas/ton de gusa)}
-    PCIratmx:= PCI/xt; 
-    
+    PCIratmx:= PCI/xt;
+
     {Conversão da massa máxima de PCI de kilogramas para toneladas}
-    PCI:=PCI/1000; 
+    PCI:=PCI/1000;
     writeln;
     repeat
       writeln('Você poderá usar no máximo ',PCI:10:3,' toneladas de PCI.');
-      
+
       {Leitura da massa de PCI adicionada}
       write('Informe um valor em toneladas:');
-      readln(PCIesc); 
+      readln(PCIesc);
 
       writeln;
 
       if PCIesc > PCI then
       begin
         textcolor(11);
-        
+
         {Aviso de digitação de valor incorreto}
-        writeln('Dado incorreto!'); 
+        writeln('Dado incorreto!');
 
         textcolor(15);
       end;
@@ -457,33 +457,33 @@ begin
     until PCIesc <= PCI;
 
     {Conversão da massa de PCI adicionada de toneladas para kilogramas}
-    PCIesc:=PCIesc*1000; 
+    PCIesc:=PCIesc*1000;
 
     {Massa total da mistura de coque a ser carregada (em kilogramas)}
-    MTC:=(24*feg-PCIesc*CF+feg*150/7+xk*h)/(TeorCM); 
-    
+    MTC:=(24*feg-PCIesc*CF+feg*150/7+xk*h)/(TeorCM);
+
     {Coke rate (em kilogramas/ton de gusa)}
-    CRate:=MTC/xt; 
-    
+    CRate:=MTC/xt;
+
     {Cálculo do coke rate mínimo (em kilogrmas/ton de gusa)}
-    CRmin:=(((feg/56+(xk*h)/1200)*12)*100)/(xt*TeorCM); 
+    CRmin:=(((feg/56+(xk*h)/1200)*12)*100)/(xt*TeorCM);
     cont:=1;
 
     while cont<= 3 do
     begin
       {Cálculo da massa ndividual de cada coque carregado (em toneladas)}
-      MasC[cont]:= (PropC[cont]*(MTC/1000))/(100); 
+      MasC[cont]:= (PropC[cont]*(MTC/1000))/(100);
       cont:= cont+1;
     end;
 
     {Cálculo do PCI rate (em kilogramas/ton de gusa)}
-    PCIrat:=PCIesc/xt; 
+    PCIrat:=PCIesc/xt;
 
     {Cálculo do Fuel rate (em kilogramas/ton de gusa)}
-    FR:= PCIrat + CRate; 
+    FR:= PCIrat + CRate;
 
     {Conversão da massa de PCI adicionada de kilogramas para toneladas}
-    PCIesc:=PCIesc/1000; 
+    PCIesc:=PCIesc/1000;
 
     clrscr;
     textcolor(12);
@@ -492,24 +492,24 @@ begin
     writeln;
     writeln;
     writeln('Informe o teor de oxigenio no sopro.');
-    
+
     {Leitura do teor de oxigênio no sopro}
-    write('Teor de oxigenio:'); 
-    readln(po2); 
-    
+    write('Teor de oxigenio:');
+    readln(po2);
+
     {Cálculo do volume}
-    Vo2:= 0.224*feg; 
+    Vo2:= 0.224*feg;
 
     {Cálculo do volume de ar a ser soprado (em Nm3)}
-    Vsopro:= Vo2/(po2/100); 
+    Vsopro:= Vo2/(po2/100);
 
     {Cálculo da vazão de sopro (em Nm3/min)}
-    Vazao:= Vsopro/1440; 
+    Vazao:= Vsopro/1440;
 
     clrscr;
-    
+
     {Apresentação dos dados de entrada e dos resultados}
-    
+
     {Apresentação dos dados de entrada}
     cont:=1;
 
@@ -521,7 +521,7 @@ begin
     end;
 
     cont:=1;
-    
+
     {Loop para funções gráficas de apresentação dos dados de entrada}
     while cont<=80 do 
     begin
@@ -531,7 +531,7 @@ begin
     end;
 
     cont:=1;
-    
+
     {Loop para funções gráficas de apresentação dos dados de entrada}
     while cont<=79 do 
     begin
@@ -546,7 +546,7 @@ begin
     gotoxy(1,4);
     write('------------------------------------GUSA:---------------------------------------');
     textcolor(15);
-    writeln('Gusa:',xt:7:2,' ton (',g:5:2,' % de Fe,',h:5:2,' % de C.).'); 
+    writeln('Gusa:',xt:7:2,' ton (',g:5:2,' % de Fe,',h:5:2,' % de C.).');
 
     {Apresentação da massa de gusa produzida 
     e dos teores presentes de ferro e carbono} 
@@ -557,57 +557,57 @@ begin
     textcolor(15);
     writeln('Minerio           Proporcao(%)           Teor(%)');
     cont:=1;
-    
+
     while cont <=t do
     begin
       {Apresentação da proporção de
       cada minério na carga e do respectivo teor de ferro}
-      writeln('Minerio ',cont,'         ',PropM[cont]:7:2,'              ',TeorM[cont]:7:2);  
+      writeln('Minerio ',cont,'         ',PropM[cont]:7:2,'              ',TeorM[cont]:7:2);
       cont:=cont+1;
     end;
 
     {Apresentação do teor médio de ferro na carga}
-    writeln('                     TEOR MEDIO DE FERRO: ',TeorMM:3:2,'%.'); 
+    writeln('                     TEOR MEDIO DE FERRO: ',TeorMM:3:2,'%.');
     textcolor(12);
-    
+
     writeln;
     writeln('-----------------------------------COQUE:--------------------------------------');
     textcolor(15);
     writeln('Coque             Proporcao(%)           Teor(%)');
-    
+
     cont:=1;
-    
+
     while cont <=y do
     begin
       {Apresentação da proporção de
       cada coque na carga e do respectivo teor de carbono fixo}
-      writeln('Coque ',cont,'           ',PropC[cont]:7:2,'              ',TeorC[cont]:7:2); 
+      writeln('Coque ',cont,'           ',PropC[cont]:7:2,'              ',TeorC[cont]:7:2);
 
       cont:=cont+1;
     end;
-    
+
     {Apresentação do
     teor médio de carbono fixo na carga}
-    writeln('                   TEOR MEDIO DE CARBONO: ',TeorCM:3:2,'%.'); 
+    writeln('                   TEOR MEDIO DE CARBONO: ',TeorCM:3:2,'%.');
 
     writeln;
-    
+
     {Apresentação do teor de carbono fixo do PCI}
-    writeln('TEOR DE CARBONO NO PCI: ',CF:3:2,'%.'); 
+    writeln('TEOR DE CARBONO NO PCI: ',CF:3:2,'%.');
 
     {Apresentação do teor de oxigênio no sopro}
-    writeln('TEOR DE OXIGENIO NO SOPRO: ',po2:3:2,'%.'); 
+    writeln('TEOR DE OXIGENIO NO SOPRO: ',po2:3:2,'%.');
 
     {Apresentação da quantidade de PCI adicionada}
-    writeln('QUANTIDADE DE PCI ADICIONADA: ',PCIesc:7:2,' ton.'); 
+    writeln('QUANTIDADE DE PCI ADICIONADA: ',PCIesc:7:2,' ton.');
 
     gotoxy(80,25);
     readkey;
     clrscr;
-    
+
     {Apresentação dos resultados}
     cont:=1;
-    
+
     {Loop para funções gráficas de apresentação dos resultados}
     while cont<=80 do
     begin
@@ -616,7 +616,7 @@ begin
     end;
 
     cont:=1;
-    
+
     {Loop para funções gráficas de apresentação dos resultados}
     while cont<=80 do
     begin
@@ -640,33 +640,33 @@ begin
     write('RESULTADOS');
     textcolor(15);
     gotoxy(1,4);
-    
+
     cont:=1;
-    
+
     while cont<= t do
     begin
       {Apresentação da massa de cada minério carregado}
-      writeln('Massa de minerio ',cont,': ',MasM[cont]:7:2,' ton.'); 
+      writeln('Massa de minerio ',cont,': ',MasM[cont]:7:2,' ton.');
       cont:=cont+1;
     end;
-    
+
     {Conversão da massa total de minério carregado de kilogramas para toneladas}
     MT:=MT/1000;
 
     textcolor(12);
-    
+
     {Massa total de minério carregado diariamente}
-    writeln('TOTAL CARREGADO: ',MT:7:2,' toneladas por dia.'); 
+    writeln('TOTAL CARREGADO: ',MT:7:2,' toneladas por dia.');
 
     textcolor(15);
     cont:=1;
-    
+
     while cont<= y do
     begin
-      
+
       {Apresentação da massa de cada coque carregado}
-      writeln('Massa do coque ',cont,': ',MasC[cont]:7:2,' ton.'); 
-      
+      writeln('Massa do coque ',cont,': ',MasC[cont]:7:2,' ton.');
+
       cont:=cont+1;
     end;
 
@@ -677,60 +677,60 @@ begin
     textcolor(12);
 
     {Massa total de coque carregado diariamente}
-    writeln('TOTAL CARREGADO: ',MTC:7:2,' toneladas por dia.'); 
+    writeln('TOTAL CARREGADO: ',MTC:7:2,' toneladas por dia.');
     textcolor(15);
     textcolor(12);
     textcolor(12);
-    
+
     {Apresentação do Coke rate obtido}
-    writeln('Coke Rate: ', CRate:7:2,' kg/ton de gusa'); 
+    writeln('Coke Rate: ', CRate:7:2,' kg/ton de gusa');
 
     textcolor(15);
-    
+
     {Apresentação do Coke rate máximo (em uma operação ALL COKE)}
-    writeln('Coke Rate maximo: ',CRmax:7:2,' kg/ton de gusa'); 
+    writeln('Coke Rate maximo: ',CRmax:7:2,' kg/ton de gusa');
 
     {Apresentação do Coke rate teórico mínimo 
     (através da utilização da quantidade máxima de PCI)}
-    writeln('Coke Rate minimo: ',CRmin:7:2,' kg/ton de gusa'); 
+    writeln('Coke Rate minimo: ',CRmin:7:2,' kg/ton de gusa');
 
     writeln;
     textcolor(12);
-    
+
     {Apresentação da massa de PCI adicionada}
-    writeln('Massa do PCI: ',PCIesc:5:2,' ton'); 
+    writeln('Massa do PCI: ',PCIesc:5:2,' ton');
 
     {Apresentação do PCI rate obtido}
-    writeln('PCI Rate: ',PCIrat :7:2,' kg/ton de gusa'); 
-    
+    writeln('PCI Rate: ',PCIrat :7:2,' kg/ton de gusa');
+
     textcolor(15);
-    
+
     {Apresentação do PCI rate máximo permitido}
-    writeln('PCI Rate maximo: ',PCIratmx:5:2,' Kg/ton de gusa'); 
+    writeln('PCI Rate maximo: ',PCIratmx:5:2,' Kg/ton de gusa');
 
     textcolor(12);
     writeln;
-    
+
     {Apresentação do Fuel rate obtido}
-    writeln('Fuel Rate: ',FR:7:2,' kg/ton de gusa'); 
+    writeln('Fuel Rate: ',FR:7:2,' kg/ton de gusa');
 
     writeln;
     textcolor(15);
-    
+
     {Apresentação do volume de oxigênio consumido}
-    writeln('Volume de oxigenio consumido: ',Vo2:5:2,'Nm3/dia.'); 
+    writeln('Volume de oxigenio consumido: ',Vo2:5:2,'Nm3/dia.');
 
     textcolor(12);
-    
+
     {Apresentação do vazão de sopro}
-    writeln('Volume de sopro: ',Vazao:5:2,'Nm3/min'); 
+    writeln('Volume de sopro: ',Vazao:5:2,'Nm3/min');
 
     textcolor(15);
     gotoxy(1,25);
-    
+
     {Finalização da
     apresentação dos dados de entrada e dos resultados}
-    write('Pressione [Enter] para ir a tela de gravacao de resultados.'); 
+    write('Pressione [Enter] para ir a tela de gravacao de resultados.');
 
     readln;
     clrscr;
@@ -740,11 +740,11 @@ begin
     writeln;
     writeln;
     writeln('Deseja criar um arquivo texto com os dados obtidos?');
-    write('Opcoes:(s)sim (n)nao?'); 
+    write('Opcoes:(s)sim (n)nao?');
     readln(resp);
     writeln;
     writeln;
-    
+
     if resp = 's' then
     begin
       assign(Texto,'Calculo.doc');
@@ -792,7 +792,7 @@ begin
       writeln(Texto,'-----------------------------------COQUE:---------------------------------------');
       writeln(Texto);
       writeln(Texto,'               Coque             Proporcao(%)           Teor(%)');
-      
+
       cont:=1;
       while cont <=y do
       begin
@@ -813,7 +813,7 @@ begin
       writeln(Texto,'                               RESULTADOS');
       writeln(Texto);
       writeln(Texto,'--------------------------------MINERIOS----------------------------------------');
-      
+
       cont:=1;
       while cont<= t do
       begin
@@ -824,7 +824,7 @@ begin
       writeln(Texto,'                        TOTAL CARREGADO: ',MT:7:2,' toneladas por dia.');
       writeln(Texto);
       writeln(Texto,'---------------------------------COQUE------------------------------------------');
-      
+
       cont:=1;
       while cont<= y do
       begin
@@ -912,6 +912,6 @@ begin
   textbackground(4);
 
   write('Pressione qualquer tecla para sair do programa.');
-  
+
   readkey;
 end.


### PR DESCRIPTION
Several typos present in current version of CARGA22.PAS, maybe due to a change in enconding since original version from 2006, were fixed based on windows-1252 version of ASCII table.

This PR closes the issue #9